### PR TITLE
add .env.* file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ sw.*
 
 # Vim swap files
 *.swp
+
+# secret for development
+config/.env.*


### PR DESCRIPTION
commitを作るたびにこれらのファイルが入らないようにのぞいたりしなきゃいけなくてめんどくさいので、gitignoreに追加して絶対にこれらのファイルがcommitに含まれないようにします